### PR TITLE
Add pytest coverage for utility functions

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,5 @@
+"""Helper utilities for upgraded-guide scripts package."""
+
+from .can_code import factorial, fibonacci
+
+__all__ = ["factorial", "fibonacci"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if PROJECT_ROOT.as_posix() not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT.as_posix())

--- a/tests/test_can_code.py
+++ b/tests/test_can_code.py
@@ -1,0 +1,54 @@
+import pytest
+
+from scripts.can_code import factorial, fibonacci
+
+
+@pytest.mark.parametrize(
+    "n, expected",
+    [
+        (0, 0),
+        (1, 1),
+        (2, 1),
+        (3, 2),
+        (10, 55),
+        (20, 6765),
+    ],
+)
+def test_fibonacci_valid_inputs(n, expected):
+    assert fibonacci(n) == expected
+
+
+@pytest.mark.parametrize("invalid", [1.5, "3", None])
+def test_fibonacci_invalid_type(invalid):
+    with pytest.raises(TypeError):
+        fibonacci(invalid)  # type: ignore[arg-type]
+
+
+def test_fibonacci_negative():
+    with pytest.raises(ValueError):
+        fibonacci(-1)
+
+
+@pytest.mark.parametrize(
+    "n, expected",
+    [
+        (0, 1),
+        (1, 1),
+        (2, 2),
+        (5, 120),
+        (10, 3628800),
+    ],
+)
+def test_factorial_valid_inputs(n, expected):
+    assert factorial(n) == expected
+
+
+@pytest.mark.parametrize("invalid", [2.2, "4", object()])
+def test_factorial_invalid_type(invalid):
+    with pytest.raises(TypeError):
+        factorial(invalid)  # type: ignore[arg-type]
+
+
+def test_factorial_negative():
+    with pytest.raises(ValueError):
+        factorial(-3)


### PR DESCRIPTION
## Summary
- add a package initializer so the scripts module can be imported
- introduce pytest-based unit tests validating fibonacci and factorial behaviors
- ensure the project root is on sys.path during tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbc6e4effc8329bc04646cde30b319